### PR TITLE
Always initialize svgDOM input value.

### DIFF
--- a/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
@@ -1,5 +1,6 @@
 package org.openmrs.module.drawing.elements;
 
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -10,6 +11,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -66,6 +68,10 @@ public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmi
 	private String fixedWidth;
 	
 	private String fixedHeight;
+	
+	private String defaultViewportWidth;
+	
+	private String defaultViewportHeight;
 	
 	private String defaultTool;
 	
@@ -156,6 +162,9 @@ public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmi
 		//Preload a "template" image into the SVG
 		String preloadImage = parameters.get("preloadResImage");
 		
+		defaultViewportWidth = "500px";
+		defaultViewportHeight = "250px";
+		
 		if (preloadImage != null) {
 			
 			//get the classes path for modules
@@ -172,8 +181,13 @@ public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmi
 			//throw if no resource was found, but if something else is going wrong
 			//this could indicate it to a module developer, even if it's not obvious to 
 			//the form designer(s)
-			base64preload = DrawingUtil.imageToBase64(preloadImageFile);
 			
+			String extension = DrawingUtil.getExtension(preloadImageFile.getName());
+			BufferedImage bi = ImageIO.read(preloadImageFile);
+			base64preload = DrawingUtil.imageToBase64(bi, extension);
+			
+			defaultViewportWidth = Integer.toString(bi.getWidth()) + "px";
+			defaultViewportHeight = Integer.toString(bi.getHeight()) + "px";
 		}
 		
 		String excludeButtons = parameters.get("excludeButtons");
@@ -332,6 +346,9 @@ public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmi
 		
 	}
 	
+	/**
+	 *
+	 */
 	@Override
 	public String generateHtml(FormEntryContext context) {
 		
@@ -418,6 +435,8 @@ public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmi
 					imageNode.setAttribute("href", base64preload);
 					imageNode.setAttribute("data-ignore-layer", "true");
 					rootSvg.appendChild(imageNode);
+					rootSvg.setAttribute("width", defaultViewportWidth);
+					rootSvg.setAttribute("height", defaultViewportHeight);
 				}
 				
 			}

--- a/omod/src/main/webapp/resources/style.css
+++ b/omod/src/main/webapp/resources/style.css
@@ -182,3 +182,8 @@
 #textarea-popup #annotation-text {
 	font-size: 1em;
 }
+
+/*_reboot.css sets svg vertical-align to "middle" which throws off the layout of the select button*/
+button svg {
+    vertical-align: unset;
+} 

--- a/omod/src/main/webapp/resources/ui.js
+++ b/omod/src/main/webapp/resources/ui.js
@@ -119,7 +119,11 @@ SVG.on(document, 'DOMContentLoaded', function() {
 		
     //store the updated markup
     updateSvgView();
-	}
+	} else {
+    //fallback to insure svgDOM is not blank, since other current factors in core, HFE and Drawing module lead to 
+    //"always" requiring creating an obs
+    storeSVG();
+  }
 
 	//this helps determine how the elements in the svg are stored, e.g. group contains marker and group with text and background
 	//which could change over time and need to be handled in a different way in e.g. addLayer()


### PR DESCRIPTION
* The recent integration of bootstrap in some modules brought in a change to SVG default styles in _reboot.css. At least in chrome, this meant setting the svg vertical-align to middle, which caused the select cursor button to no longer line up with the other tool buttons. (Mostly cosmetic and theoretically doesn't "fix" it for style sheets that set buttons or icons (like those used in other tool buttons) to a different vertical align). 

 ### If forms included this widget in a collapsed accordian fold:

* If the fold was never expanded the height and width always remained 0, and the svgDOM was never set. This update sets the svgDOM input value to whatever the server provided. This should be sufficient for later views or edits.

* Some bug reports have included images where SVG dimensions where smaller than the preloaded image dimension. This PR also retrieves the height and width of the image on the server and uses it to set the height and width attributes of the SVG in the submission element generateHtml method.
