### PR TITLE
Upgrade HFE dependency to 3.10.0-SNAPSHOT.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -59,6 +59,14 @@
 			<version>${htmlformentryVersion}</version>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>htmlformentry-api-2.2</artifactId>
+			<version>${htmlformentryVersion}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		
 		<!-- Adding HFE test-jar, allows utilizing RegressionTestHelper class -->
 		<dependency>

--- a/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
@@ -8,7 +8,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.imageio.ImageIO;
@@ -291,24 +290,6 @@ public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmi
 				
 				actions.modifyObs(parentObs, questionConcept,
 				    new ComplexData(DrawingConstants.BASE_COMPLEX_OBS_FILENAME, svgByteArray), null, null);
-				
-				//should the modify codepath already handle setting previousObs?
-				//the new HFE code should handle this
-				Obs[] newObs = session.getSubmissionActions().getObsToCreate().parallelStream().filter(new Predicate<Obs>() {
-					
-					@Override
-					public boolean test(Obs curObsToCreate) {
-						if (curObsToCreate.isComplex() && curObsToCreate.getComplexData() != null
-						        && svgByteArray.equals(curObsToCreate.getComplexData().getData())) {
-							return true;
-						}
-						
-						return false;
-					}
-					
-				}).toArray(Obs[]::new);
-				
-				newObs[0].setPreviousVersion(parentObs);
 				
 			} else {
 				

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   <properties>
     <openmrsPlatformVersion>2.2.0</openmrsPlatformVersion>
     <uiframeworkVersion>3.9</uiframeworkVersion>
-    <htmlformentryVersion>3.10.0-SNAPSHOT</htmlformentryVersion>
+    <htmlformentryVersion>3.10.0</htmlformentryVersion>
     <legacyuiVersion>1.5.0</legacyuiVersion>
     <svgdotdrawdotjsVersion>2.0.3</svgdotdrawdotjsVersion>
     <javaxServletApiVersion>3.0.1</javaxServletApiVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
   </modules>
 
   <properties>
-    <openMRSVersion>2.2.0</openMRSVersion>
+    <openmrsPlatformVersion>2.2.0</openmrsPlatformVersion>
     <uiframeworkVersion>3.9</uiframeworkVersion>
-    <htmlformentryVersion>3.9.2</htmlformentryVersion>
+    <htmlformentryVersion>3.10.0-SNAPSHOT</htmlformentryVersion>
     <legacyuiVersion>1.5.0</legacyuiVersion>
     <svgdotdrawdotjsVersion>2.0.3</svgdotdrawdotjsVersion>
     <javaxServletApiVersion>3.0.1</javaxServletApiVersion>
@@ -57,35 +57,35 @@
       <dependency>
         <groupId>org.openmrs.api</groupId>
         <artifactId>openmrs-api</artifactId>
-        <version>${openMRSVersion}</version>
+        <version>${openmrsPlatformVersion}</version>
         <type>jar</type>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.openmrs.web</groupId>
         <artifactId>openmrs-web</artifactId>
-        <version>${openMRSVersion}</version>
+        <version>${openmrsPlatformVersion}</version>
         <type>jar</type>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.openmrs.api</groupId>
         <artifactId>openmrs-api</artifactId>
-        <version>${openMRSVersion}</version>
+        <version>${openmrsPlatformVersion}</version>
         <type>test-jar</type>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.openmrs.web</groupId>
         <artifactId>openmrs-web</artifactId>
-        <version>${openMRSVersion}</version>
+        <version>${openmrsPlatformVersion}</version>
         <type>test-jar</type>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.openmrs.test</groupId>
         <artifactId>openmrs-test</artifactId>
-        <version>${openMRSVersion}</version>
+        <version>${openmrsPlatformVersion}</version>
         <type>pom</type>
         <scope>test</scope>
       </dependency>
@@ -140,7 +140,7 @@
             <dependency>
               <groupId>org.openmrs.tools</groupId>
               <artifactId>openmrs-tools</artifactId>
-              <version>${openMRSVersion}</version>
+              <version>${openmrsPlatformVersion}</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
removing makeshift prev obs linking in edit mode, updating to hfe 3.10.0-SNAPSHOT to rely on its new modifyObs() behavior from fix for HTML-675 to link to previous version of Obs