### PR TITLE
Removed DefaultAnnotationHandlerMapping bean definition

### DIFF
--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -25,10 +25,6 @@
 
 	<!-- Add here beans related to the web context -->
 
-	 
-	<!-- Annotation based controllers -->
-	<bean class="org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping"/>
-	
 	<bean id="drawingWindowPortletController" class="org.openmrs.module.drawing.web.controller.DrawingWindowPortletController">
     </bean>
     


### PR DESCRIPTION
- Removed DefaultAnnotationHandlerMapping bean definition in order to allow module to be used on both spring 4 and 5.
- Change done in context of preparation for OpenMRS Platform 2.4 release
https://talk.openmrs.org/t/platform-2-4-release-to-dos-and-release-discussions-thread/30616/70