### PR TITLE
RA-1923 - Update repository from http to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <repository>
       <id>openmrs-repo</id>
       <name>OpenMRS Nexus Repository</name>
-      <url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+      <url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
     </repository>
   </repositories>
 
@@ -160,7 +160,7 @@
     <pluginRepository>
       <id>openmrs-repo</id>
       <name>OpenMRS Nexus Repository</name>
-      <url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+      <url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -171,12 +171,12 @@
     <repository>
       <id>openmrs-repo-modules</id>
       <name>Modules</name>
-      <url>http://mavenrepo.openmrs.org/nexus/content/repositories/modules/</url>
+      <url>https://mavenrepo.openmrs.org/nexus/content/repositories/modules/</url>
     </repository>
     <snapshotRepository>
       <id>openmrs-repo-snapshots</id>
       <name>OpenMRS Snapshots</name>
-      <url>http://mavenrepo.openmrs.org/nexus/content/repositories/snapshots</url>
+      <url>https://mavenrepo.openmrs.org/nexus/content/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 


### PR DESCRIPTION
Problem:
The project was not building.
This was due to the use of http instead of https in the repository URL