### PR TITLE
RA-1952 NPE when open a form if the drawing file is missing

### DIFF
--- a/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
@@ -554,7 +554,7 @@ public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmi
 			widgetMarkup = "<span style='color:red;'>Error loading drawing element</span>";
 		}
 		
-		//If the file that contains the drawing for some reason dont exists, show an error message and send a new drawing.
+		//If the file that contains the drawing for some reason doesn't exist, show an error message and send a new drawing.
 		if (parentObs != null && parentObs.getComplexData().getData() == null && context.getMode() != Mode.ENTER) {
 			widgetMarkup = "<span style='color:red;'>"
 			        + Context.getMessageSourceService().getMessage("drawing.error.getting.drawing.file") + "</span>"

--- a/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
@@ -411,7 +411,7 @@ public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmi
 					
 				}
 				
-			} else if (ctxMode == Mode.ENTER || parentObs.getComplexData().getData() == null) {
+			} else if (ctxMode == Mode.ENTER || ( parentObs != null && parentObs.getComplexData().getData() == null) ) {
 				
 				//the image only needs to be added if this is a new form being entered
 				if (base64preload != null) {

--- a/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
@@ -369,7 +369,8 @@ public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmi
 			//DrawingUtil.translateLanguageKey("drawing.save");
 			
 			//in both view and edit, load the existing svg if it exists
-			if ((ctxMode == Mode.VIEW || ctxMode == Mode.EDIT) && parentObs != null) {
+			if ((ctxMode == Mode.VIEW || ctxMode == Mode.EDIT) && parentObs != null
+			        && parentObs.getComplexData().getData() != null) {
 				
 				AnnotatedImage ai = new AnnotatedImage(new String((byte[]) parentObs.getComplexData().getData()));
 				
@@ -410,7 +411,7 @@ public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmi
 					
 				}
 				
-			} else if (ctxMode == Mode.ENTER) {
+			} else if (ctxMode == Mode.ENTER || parentObs.getComplexData().getData() == null) {
 				
 				//the image only needs to be added if this is a new form being entered
 				if (base64preload != null) {
@@ -551,6 +552,13 @@ public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmi
 		
 		if (widgetMarkup == null || widgetMarkup.isEmpty()) {
 			widgetMarkup = "<span style='color:red;'>Error loading drawing element</span>";
+		}
+		
+		//If the file that contains the drawing for some reason dont exists, show an error message and send a new drawing.
+		if (parentObs != null && parentObs.getComplexData().getData() == null && context.getMode() != Mode.ENTER) {
+			widgetMarkup = "<span style='color:red;'>"
+			        + Context.getMessageSourceService().getMessage("drawing.error.getting.drawing.file") + "</span>"
+			        + widgetMarkup;
 		}
 		
 		String js = "<script src=\"../../moduleResources/drawing/svg.js\"></script>"

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -25,3 +25,4 @@ drawing.addTemplate=Add Template
 drawing.drawingEditor=Drawing Editor
 drawing.doneDrawing=Done Drawing
 drawing.savedDrawing=DRAWING SAVED
+drawing.error.getting.drawing.file=Error loading the drawing file.


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/RA-1952

Add a message if the old drawing file was not possible to open, and the user will see a black drawing.
![image](https://user-images.githubusercontent.com/72515287/131879252-516b3069-12c5-4dcc-8654-afed17f544ed.png)

